### PR TITLE
Support dynamic select

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The loop will break when the channel is closed.
 
 `none { ... }` if none of the channel operations were ready, none will execute instead. 
 
-`forEach(chs) { ch in ... }` operate on an array of channels.
+`forEach(seq) { el in ... }` operates on a sequence. It is useful for working with an array of channels.
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ The loop will break when the channel is closed.
 
 `none { ... }` if none of the channel operations were ready, none will execute instead. 
 
+`forEach(chs) { ch in ... }` operate on an array of channels.
+
 ### Examples
 
 ```swift

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The loop will break when the channel is closed.
 
 `none { ... }` if none of the channel operations were ready, none will execute instead. 
 
-`any(seq) { el in ... }` operates on a sequence. It is useful for working with an array of channels.
+`any(x1, x2, ...) { x in ... }` or `any(seq) { el in ... }` operates on a sequence and is useful for working with an array of channels.
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The loop will break when the channel is closed.
 
 `none { ... }` if none of the channel operations were ready, none will execute instead. 
 
-`forEach(seq) { el in ... }` operates on a sequence. It is useful for working with an array of channels.
+`any(seq) { el in ... }` operates on a sequence. It is useful for working with an array of channels.
 
 ### Examples
 

--- a/Sources/AsyncChannels/Select.swift
+++ b/Sources/AsyncChannels/Select.swift
@@ -83,8 +83,8 @@ struct SendHandler<T>: SelectProtocol {
 
 @resultBuilder
 public struct SelectCollector {
-    public static func buildBlock(_ handlers: SelectHandler...) -> [SelectHandler] {
-        return handlers
+    public static func buildBlock(_ handlers: [SelectHandler]...) -> [SelectHandler] {
+        return handlers.reduce([], +)
     }
 }
 
@@ -118,37 +118,43 @@ public func select(@SelectCollector cases: () -> ([SelectHandler])) async {
 
 @inlinable
 @inline(__always)
-public func receive<T>(_ chan: Channel<T>, _ outFunc: @escaping (T?) async -> ()) -> SelectHandler {
-    return SelectHandler(inner: ReceiveHandler(chan: chan, outFunc: outFunc))
+public func receive<T>(_ chan: Channel<T>, _ outFunc: @escaping (T?) async -> ()) -> [SelectHandler] {
+    return [SelectHandler(inner: ReceiveHandler(chan: chan, outFunc: outFunc))]
 }
 
 @inlinable
 @inline(__always)
-public func receive<T>(_ chan: Channel<T>, _ outFunc: @escaping () async -> ()) -> SelectHandler {
-    return SelectHandler(inner: ReceiveHandler(chan: chan, outFunc: { _ in await outFunc() }))
+public func receive<T>(_ chan: Channel<T>, _ outFunc: @escaping () async -> ()) -> [SelectHandler] {
+    return [SelectHandler(inner: ReceiveHandler(chan: chan, outFunc: { _ in await outFunc() }))]
 }
 
 @inlinable
 @inline(__always)
-public func receive<T>(_ chan: Channel<T>) -> SelectHandler {
-    return SelectHandler(inner: ReceiveHandler(chan: chan, outFunc: { _ in }))
+public func receive<T>(_ chan: Channel<T>) -> [SelectHandler] {
+    return [SelectHandler(inner: ReceiveHandler(chan: chan, outFunc: { _ in }))]
 }
 
 @inlinable
 @inline(__always)
-public func send<T>(_ val: T, to chan: Channel<T>) -> SelectHandler {
-    return SelectHandler(inner: SendHandler(chan: chan, val: val, onSend: {}))
+public func send<T>(_ val: T, to chan: Channel<T>) -> [SelectHandler] {
+    return [SelectHandler(inner: SendHandler(chan: chan, val: val, onSend: {}))]
 }
 
 @inlinable
 @inline(__always)
-public func send<T>(_ val: T, to chan: Channel<T>, _ onSend: @escaping () async -> ()) -> SelectHandler {
-    return SelectHandler(inner: SendHandler(chan: chan, val: val, onSend: onSend))
+public func send<T>(_ val: T, to chan: Channel<T>, _ onSend: @escaping () async -> ()) -> [SelectHandler] {
+    return [SelectHandler(inner: SendHandler(chan: chan, val: val, onSend: onSend))]
 }
 
 @inlinable
 @inline(__always)
-public func none(handler: @escaping () async -> ()) -> SelectHandler {
-    return SelectHandler(inner: NoneHandler(handler: handler))
+public func none(handler: @escaping () async -> ()) -> [SelectHandler] {
+    return [SelectHandler(inner: NoneHandler(handler: handler))]
+}
+
+@inlinable
+@inline(__always)
+public func forEach<T>(_ chans: [Channel<T>], @SelectCollector cases: (Channel<T>) -> ([SelectHandler])) -> [SelectHandler] {
+    return chans.flatMap { cases($0) }
 }
 

--- a/Sources/AsyncChannels/Select.swift
+++ b/Sources/AsyncChannels/Select.swift
@@ -158,3 +158,8 @@ public func any<S, T>(_ seq: S, @SelectCollector cases: (T) -> ([SelectHandler])
     return seq.flatMap { cases($0) }
 }
 
+@inlinable
+@inline(__always)
+public func any<T>(_ elements: T..., @SelectCollector cases: (T) -> ([SelectHandler])) -> [SelectHandler] {
+    return elements.flatMap { cases($0) }
+}

--- a/Sources/AsyncChannels/Select.swift
+++ b/Sources/AsyncChannels/Select.swift
@@ -154,7 +154,7 @@ public func none(handler: @escaping () async -> ()) -> [SelectHandler] {
 
 @inlinable
 @inline(__always)
-public func forEach<S, T>(_ seq: S, @SelectCollector cases: (T) -> ([SelectHandler])) -> [SelectHandler] where S: Sequence, S.Element == T {
+public func any<S, T>(_ seq: S, @SelectCollector cases: (T) -> ([SelectHandler])) -> [SelectHandler] where S: Sequence, S.Element == T {
     return seq.flatMap { cases($0) }
 }
 

--- a/Sources/AsyncChannels/Select.swift
+++ b/Sources/AsyncChannels/Select.swift
@@ -154,7 +154,7 @@ public func none(handler: @escaping () async -> ()) -> [SelectHandler] {
 
 @inlinable
 @inline(__always)
-public func forEach<T>(_ chans: [Channel<T>], @SelectCollector cases: (Channel<T>) -> ([SelectHandler])) -> [SelectHandler] {
-    return chans.flatMap { cases($0) }
+public func forEach<S, T>(_ seq: S, @SelectCollector cases: (T) -> ([SelectHandler])) -> [SelectHandler] where S: Sequence, S.Element == T {
+    return seq.flatMap { cases($0) }
 }
 

--- a/Tests/AsyncChannelsTests/AsyncChannelTests.swift
+++ b/Tests/AsyncChannelsTests/AsyncChannelTests.swift
@@ -212,7 +212,34 @@ final class AsyncTest: XCTestCase {
         let r = await result.reduce(into: []) { $0.append($1) }
         XCTAssertEqual(["foo", "bar"].sorted(), r.sorted())
     }
-    
+        
+    func testDynamicSelect() async {
+        let a = Channel<String>()
+        let b = Channel<String>()
+        let result = Channel<String>(capacity: 2)
+        
+        Task {
+            await a <- "foo"
+            await b <- "bar"
+        }
+        
+        await select {
+            forEach([a, b]) {
+                receive($0) { await result <- $0! }
+            }
+        }
+        
+        await select {
+            forEach([a, b]) {
+                receive($0) { await result <- $0! }
+            }
+        }
+        result.close()
+        
+        let r = await result.reduce(into: []) { $0.append($1) }
+        XCTAssertEqual(["foo", "bar"].sorted(), r.sorted())
+    }
+
     func testBufferSelect() async {
         let c = Channel<String>(capacity: 3)
         let d = Channel<String>(capacity: 3)

--- a/Tests/AsyncChannelsTests/AsyncChannelTests.swift
+++ b/Tests/AsyncChannelsTests/AsyncChannelTests.swift
@@ -224,13 +224,13 @@ final class AsyncTest: XCTestCase {
         }
         
         await select {
-            forEach([a, b]) {
+            any([a, b]) {
                 receive($0) { await result <- $0! }
             }
         }
         
         await select {
-            forEach([a, b]) {
+            any([a, b]) {
                 receive($0) { await result <- $0! }
             }
         }

--- a/Tests/AsyncChannelsTests/AsyncChannelTests.swift
+++ b/Tests/AsyncChannelsTests/AsyncChannelTests.swift
@@ -239,6 +239,33 @@ final class AsyncTest: XCTestCase {
         let r = await result.reduce(into: []) { $0.append($1) }
         XCTAssertEqual(["foo", "bar"].sorted(), r.sorted())
     }
+    
+func testDynamicVariadicSelect() async {
+    let a = Channel<String>()
+    let b = Channel<String>()
+    let result = Channel<String>(capacity: 2)
+    
+    Task {
+        await a <- "foo"
+        await b <- "bar"
+    }
+    
+    await select {
+        any(a, b) {
+            receive($0) { await result <- $0! }
+        }
+    }
+    
+    await select {
+        any(a, b) {
+            receive($0) { await result <- $0! }
+        }
+    }
+    result.close()
+    
+    let r = await result.reduce(into: []) { $0.append($1) }
+    XCTAssertEqual(["foo", "bar"].sorted(), r.sorted())
+}
 
     func testBufferSelect() async {
         let c = Channel<String>(capacity: 3)


### PR DESCRIPTION
This PR allows `select` to accept an array of channels. Previously, there was no way to `select` an array of channels. This PR only modifies functions related to `resultBuilders`, so the behavior of the channels will remain unchanged.