### PR TITLE
Fix strict concurrency errors in `blockingReceive` functions

### DIFF
--- a/Sources/AsyncChannels/Channel+Extensions.swift
+++ b/Sources/AsyncChannels/Channel+Extensions.swift
@@ -31,7 +31,7 @@ extension Channel {
     /// Do not use this function in an async task!
     public func blockingReceive() -> T? {
         let semaphore = DispatchSemaphore(value: 0)
-        var val: T?
+        nonisolated(unsafe) var val: T?
         Task {
             val = await <-self
             semaphore.signal()

--- a/Sources/AsyncChannels/ThrowingChannel+Extensions.swift
+++ b/Sources/AsyncChannels/ThrowingChannel+Extensions.swift
@@ -32,7 +32,7 @@ extension ThrowingChannel {
     /// Do not use this function in an async task!
     public func blockingReceive() -> T? {
         let semaphore = DispatchSemaphore(value: 0)
-        var val: T?
+        nonisolated(unsafe) var val: T?
         Task {
             val = await <-self
             semaphore.signal()


### PR DESCRIPTION
This turned into an error on my machine on Swift 6.3 on Xcode 26.4.

This change just marks the captured `val` as `nonisolated(unsafe)` in `blockingReceive()` for both `Channel` and `ThrowingChannel`, since the DispatchSemaphore already guarantees safe access ordering.

Please let me know if this makes sense to you, and thank you for creating this library!