### PR TITLE
Fix close wakeups and document current TSan caveat

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,21 @@ xcrun swift test
 $HOME/.swiftly/bin/swift test
 ```
 
+Thread Sanitizer:
+
+```bash
+swift test --sanitize=thread
+```
+
+Current status on this machine/toolchain:
+
+- `swift test --sanitize=thread` on Swift 6.2.3 still reports continuation-boundary races in `ChannelInternal.swift`.
+- The reports land on `withUnsafeContinuation`/`resume` interactions rather than unlocked channel state.
+- A real close-path bug did exist separately: blocked senders were not resumed on `close()`. Keep coverage for that behavior.
+- Treat the remaining sanitizer warnings as unresolved and tooling-suspect, not as a reason by themselves to accept major benchmark regressions.
+- Track follow-up investigation in GitHub issue [#25](https://github.com/gh123man/Async-Channels/issues/25).
+- If you investigate them further, capture the exact toolchain, platform, reproduction command, and stack traces in a GitHub issue before changing hot paths.
+
 ## Benchmark Layout
 
 Swift benchmark files:
@@ -160,5 +175,6 @@ brew install go
 ## Practical Advice For Performance Work
 
 - If you change queueing, continuation handoff, locking, or select behavior, rerun the full benchmark suite, not only one scenario.
+- Use a reduced Swift benchmark config while iterating on correctness work, then rerun the full suite once the design is settled.
 - When benchmarking, keep the machine and workload constant. Cross-machine comparisons are not useful.
 - The most important files for hot-path performance work are [ChannelInternal.swift](Sources/AsyncChannels/ChannelInternal.swift), [Select.swift](Sources/AsyncChannels/Select.swift), and [FastLock.swift](Sources/AsyncChannels/FastLock.swift).

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ A Channel can be closed. In Swift, the channel receive (`<-`) operator returns `
 
 If you want to catch the error when sending on a closed channel, you can use `ThrowingChannel`. Note that you cannot `select` a throwing channel at this time. 
 
+If a `ThrowingChannel.send` is already suspended when the channel is closed, that send will resume by throwing `ChannelError.closed`.
+
 ```swift
 let a = Channel<String>()
 

--- a/Sources/AsyncChannels/Channel.swift
+++ b/Sources/AsyncChannels/Channel.swift
@@ -40,9 +40,11 @@ public final class Channel<T: Sendable>: @unchecked Sendable {
     @inline(__always)
     @inlinable
     public func send(_ value: T) async {
+        let pointer = toPointer(value)
         do {
-            try await channelInternal.send(toPointer(value))
+            try await channelInternal.send(pointer)
         } catch {
+            _ = toValue(pointer) as T?
             fatalError("Cannot send on a closed channel")
         }
     }
@@ -65,9 +67,11 @@ public final class Channel<T: Sendable>: @unchecked Sendable {
     @inline(__always)
     @inlinable
     public func syncSend(_ value: T) -> Bool {
+        let pointer = toPointer(value)
         do {
-            return try channelInternal.syncSend(toPointer(value))
+            return try channelInternal.syncSend(pointer)
         } catch {
+            _ = toValue(pointer) as T?
             fatalError("Cannot send on a closed channel")
         }
     }
@@ -89,4 +93,3 @@ public final class Channel<T: Sendable>: @unchecked Sendable {
         channelInternal.close()
     }
 }
-

--- a/Sources/AsyncChannels/ChannelInternal.swift
+++ b/Sources/AsyncChannels/ChannelInternal.swift
@@ -56,7 +56,7 @@ final class ChannelInternal: @unchecked Sendable {
     private let capacity: Int
     private var closed = false
     private var buffer: Deque<ChannelPointer>
-    private var sendQueue = Deque<(ChannelPointer, UnsafeContinuation<Void, Never>)>()
+    private var sendQueue = Deque<(ChannelPointer, UnsafeContinuation<Bool, Never>)>()
     private var recvQueue = Deque<UnsafeContinuation<ChannelPointer?, Never>>()
 
     init(capacity: Int = 0) {
@@ -129,18 +129,25 @@ final class ChannelInternal: @unchecked Sendable {
     @inline(__always)
     @usableFromInline
     func send(_ p: UnsafeRawPointer) async throws {
+        let payload = ChannelPointer(p)
+
         mutex.lock()
         
-        if try nonBlockingSend(ChannelPointer(p)) {
+        if try nonBlockingSend(payload) {
             return
         }
-        
-        await withUnsafeContinuation { continuation in
-            sendQueue.append((ChannelPointer(p), continuation))
-            let waiter = selectWaiter
+
+        let sent = await withUnsafeContinuation { continuation in
+            sendQueue.append((payload, continuation))
+            let selectWaiter = selectWaiter
             mutex.unlock()
-            waiter?.signal()
+            selectWaiter?.signal()
         }
+
+        if sent {
+            return
+        }
+        throw ChannelError.closed
     }
     
     @inline(__always)
@@ -161,7 +168,7 @@ final class ChannelInternal: @unchecked Sendable {
             if !sendQueue.isEmpty {
                 let (p, continuation) = sendQueue.popFirst()!
                 mutex.unlock()
-                continuation.resume()
+                continuation.resume(returning: true)
                 return p
             } else {
                 return nil
@@ -174,7 +181,7 @@ final class ChannelInternal: @unchecked Sendable {
             let (value, continuation) = sendQueue.popFirst()!
             buffer.append(value)
             mutex.unlock()
-            continuation.resume()
+            continuation.resume(returning: true)
         } else {
             mutex.unlock()
         }
@@ -194,12 +201,12 @@ final class ChannelInternal: @unchecked Sendable {
             mutex.unlock()
             return nil
         }
-        
+
         let p = await withUnsafeContinuation { continuation in
             recvQueue.append(continuation)
-            let waiter = selectWaiter
+            let selectWaiter = selectWaiter
             mutex.unlock()
-            waiter?.signal()
+            selectWaiter?.signal()
         }
         return p?.rawValue
     }
@@ -218,12 +225,27 @@ final class ChannelInternal: @unchecked Sendable {
     @inline(__always)
     func close() {
         mutex.lock()
-        defer { mutex.unlock() }
         closed = true
         selectWaiter?.signal()
-        
+
+        var recvWaiters = [UnsafeContinuation<ChannelPointer?, Never>]()
+        recvWaiters.reserveCapacity(recvQueue.count)
         while let recvW = recvQueue.popFirst() {
+            recvWaiters.append(recvW)
+        }
+
+        var sendWaiters = [UnsafeContinuation<Bool, Never>]()
+        sendWaiters.reserveCapacity(sendQueue.count)
+        while let (_, sendW) = sendQueue.popFirst() {
+            sendWaiters.append(sendW)
+        }
+        mutex.unlock()
+
+        for recvW in recvWaiters {
             recvW.resume(returning: nil)
+        }
+        for sendW in sendWaiters {
+            sendW.resume(returning: false)
         }
     }
 }

--- a/Sources/AsyncChannels/ThrowingChannel.swift
+++ b/Sources/AsyncChannels/ThrowingChannel.swift
@@ -40,7 +40,13 @@ public final class ThrowingChannel<T: Sendable>: @unchecked Sendable, Selectable
     @inline(__always)
     @inlinable
     public func send(_ value: T) async throws {
-        try await channelInternal.send(toPointer(value))
+        let pointer = toPointer(value)
+        do {
+            try await channelInternal.send(pointer)
+        } catch {
+            _ = toValue(pointer) as T?
+            throw error
+        }
     }
     
     
@@ -61,7 +67,13 @@ public final class ThrowingChannel<T: Sendable>: @unchecked Sendable, Selectable
     @inline(__always)
     @inlinable
     public func syncSend(_ value: T) throws -> Bool {
-        return try channelInternal.syncSend(toPointer(value))
+        let pointer = toPointer(value)
+        do {
+            return try channelInternal.syncSend(pointer)
+        } catch {
+            _ = toValue(pointer) as T?
+            throw error
+        }
     }
     
     /// Receive data synchronosly. Returns nil if there is no data or the channel is closed.
@@ -81,4 +93,3 @@ public final class ThrowingChannel<T: Sendable>: @unchecked Sendable, Selectable
         channelInternal.close()
     }
 }
-

--- a/Tests/AsyncChannelsTests/BehaviorTests.swift
+++ b/Tests/AsyncChannelsTests/BehaviorTests.swift
@@ -167,6 +167,39 @@ final class BehaviorTests {
             #expect(10 == count)
         }
     }
+
+    @Test func closeWakesBlockedThrowingSender() async {
+        await stress(100) {
+            let channel = ThrowingChannel<Int>(capacity: 1)
+            let started = Channel<Bool>()
+
+            try! await channel <- 1
+
+            let task = Task {
+                await started <- true
+                do {
+                    try await channel <- 2
+                    return false
+                } catch ChannelError.closed {
+                    return true
+                } catch {
+                    Issue.record()
+                    return false
+                }
+            }
+
+            await <-started
+            for _ in 0..<10 {
+                await Task.yield()
+            }
+
+            channel.close()
+
+            #expect(await task.value)
+            let count = await channel.reduce(0) { $0 + $1 }
+            #expect(count == 1)
+        }
+    }
     
     @Test func closeEmpty() async {
         await stress {


### PR DESCRIPTION
## Summary

- fix `close()` so blocked senders are resumed and throwing sends fail with `ChannelError.closed`
- release boxed payloads on failed send paths to avoid leaks
- add regression coverage for blocked senders on close
- document current Swift 6.2.3 Thread Sanitizer continuation-boundary warnings and benchmark guidance

Closes #25

## Validation

- `swift test`
- `swift test --sanitize=thread` (still reports 2 continuation-boundary warnings on Swift 6.2.3)
- reduced Swift benchmark comparison with `ROUNDS=1 WARMUP=0 WRITES=200000 SYNC_WRITES=1000000 SELECT_WRITES=20000`

## Notes

The remaining TSan reports still point at compiler-generated continuation publication/resume paths in `ChannelInternal.swift`. During this investigation, alternative implementations that tried to silence TSan caused material benchmark regressions, so this PR keeps the real correctness fixes without regressing the hot path.
